### PR TITLE
Bump groundlight to v0.24.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "framegrab>=0.11.3",
-    "groundlight>=0.23.3",
+    "groundlight>=0.24.0",
     "jsonformatter>=0.3.4",
     "numpy<2.0.0",
     "opencv-python-headless>=4.11.0.86",


### PR DESCRIPTION
The latest version of groundlight prevents an incompatibility with urllib3 2.6.0 that was impacting some users of stream, and also incorporates some new features.